### PR TITLE
Upgrade to PISE 0.30.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,10 @@ on:
         default: "WIP"
 jobs:
   build-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Build
-        uses: proofscape/pfsc-repo-build-action@v2
+        uses: proofscape/pfsc-repo-build-action@v3
         with:
+          pise-vers: 0.30.1
           content-vers: ${{inputs.content-vers || 'WIP' }}

--- a/G/auss/DA/Sec7/Art343.pfsc
+++ b/G/auss/DA/Sec7/Art343.pfsc
@@ -17,16 +17,16 @@ of generator $g$.
 
 <param:eg_n>[]{
     ptype: "Prime",
-    name: "n",
+    tex: "n",
     init: 19,
     args: {
-      chooser_upper_bound: 100,
+      chooserUpperBound: 100,
     },
 }
 
 <param:eg_g>[]{
     ptype: "PrimRes",
-    name: "g",
+    tex: "g",
     import: {
         m: eg_n,
     },
@@ -35,7 +35,7 @@ of generator $g$.
 
 <param:eg_G>[]{
     ptype: "PrimRes",
-    name: "G",
+    tex: "G",
     import: {
         m: eg_n,
     },
@@ -44,7 +44,7 @@ of generator $g$.
 
 <param:eg_e>[]{
     ptype: "Divisor",
-    name: "e",
+    tex: "e",
     import: {
         n: eg_n,
     },
@@ -56,7 +56,6 @@ of generator $g$.
 
 <param:eg_lam>[]{
     ptype: "Integer",
-    name: "lam",
     tex: "\lambda",
     import: {
         lt: eg_n,

--- a/G/auss/DA/Sec7/Art343.pfsc
+++ b/G/auss/DA/Sec7/Art343.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/G/auss/DA/Sec7/Art343.pfsc
+++ b/G/auss/DA/Sec7/Art343.pfsc
@@ -18,7 +18,7 @@ of generator $g$.
 <param:eg_n>[]{
     ptype: "Prime",
     name: "n",
-    default: 19,
+    init: 19,
     args: {
       chooser_upper_bound: 100,
     },
@@ -30,7 +30,7 @@ of generator $g$.
     import: {
         m: eg_n,
     },
-    default: 2,
+    init: 2,
 }
 
 <param:eg_G>[]{
@@ -39,7 +39,7 @@ of generator $g$.
     import: {
         m: eg_n,
     },
-    default: 10,
+    init: 10,
 }
 
 <param:eg_e>[]{
@@ -51,7 +51,7 @@ of generator $g$.
     args: {
         dividing: "n - 1",
     },
-    default: 3,
+    init: 3,
 }
 
 <param:eg_lam>[]{
@@ -64,7 +64,7 @@ of generator $g$.
     args: {
         gt: 0,
     },
-    default: 1,
+    init: 1,
 }
 
 <disp:eg_disp1>[]{

--- a/H/ilbert/ZB/Lem18.pfsc
+++ b/H/ilbert/ZB/Lem18.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/H/ilbert/ZB/Pg369_2.pfsc
+++ b/H/ilbert/ZB/Pg369_2.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/H/ilbert/ZB/Thm117.pfsc
+++ b/H/ilbert/ZB/Thm117.pfsc
@@ -36,7 +36,7 @@ Examples:
     ptype: "Prime",
     name: "ell",
     tex: "\ell",
-    default: 7,
+    init: 7,
     args: {
         odd: True,
     },
@@ -45,7 +45,7 @@ Examples:
 <param:eg1_g>[]{
     ptype: "Integer",
     name: "g",
-    default: 3,
+    init: 3,
     import: {
         coprime_to: eg1_ell,
     },

--- a/H/ilbert/ZB/Thm117.pfsc
+++ b/H/ilbert/ZB/Thm117.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/H/ilbert/ZB/Thm117.pfsc
+++ b/H/ilbert/ZB/Thm117.pfsc
@@ -34,7 +34,6 @@ Examples:
 
 <param:eg1_ell>[]{
     ptype: "Prime",
-    name: "ell",
     tex: "\ell",
     init: 7,
     args: {
@@ -44,10 +43,10 @@ Examples:
 
 <param:eg1_g>[]{
     ptype: "Integer",
-    name: "g",
+    tex: "g",
     init: 3,
     import: {
-        coprime_to: eg1_ell,
+        coprimeTo: eg1_ell,
     },
     args: {
         gt: 1,

--- a/H/ilbert/ZB/Thm118.pfsc
+++ b/H/ilbert/ZB/Thm118.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/H/ilbert/ZB/Thm17.pfsc
+++ b/H/ilbert/ZB/Thm17.pfsc
@@ -28,7 +28,7 @@ integral basis for $k$:
 
 <param:eg1_k>[]{
     ptype: "NumberField",
-    name: "k",
+    tex: "k",
     init: "cyc(7)",
     args: {
         gen: "zeta",
@@ -54,16 +54,15 @@ prime $frp@$ lying over $p$ in $k$:
 <param:eg1_p>[]{
     ptype: "Prime",
     context: "AlgNT",
-    name: "p",
+    tex: "p",
     init: 11,
     args: {
-        chooser_upper_bound: 173
+        chooserUpperBound: 173
     }
 }
 
 <param:eg1_frp>[]{
     ptype: "PrimeIdeal",
-    name: "frp",
     tex: "\mathfrak{p}",
     import: {
         k: eg1_k,

--- a/H/ilbert/ZB/Thm17.pfsc
+++ b/H/ilbert/ZB/Thm17.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/H/ilbert/ZB/Thm17.pfsc
+++ b/H/ilbert/ZB/Thm17.pfsc
@@ -29,7 +29,7 @@ integral basis for $k$:
 <param:eg1_k>[]{
     ptype: "NumberField",
     name: "k",
-    default: "cyc(7)",
+    init: "cyc(7)",
     args: {
         gen: "zeta",
     },
@@ -55,7 +55,7 @@ prime $frp@$ lying over $p$ in $k$:
     ptype: "Prime",
     context: "AlgNT",
     name: "p",
-    default: 11,
+    init: 11,
     args: {
         chooser_upper_bound: 173
     }

--- a/H/ilbert/ZB/Thm90.pfsc
+++ b/H/ilbert/ZB/Thm90.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #

--- a/__.pfsc
+++ b/__.pfsc
@@ -9,6 +9,6 @@
 
 version = "v0.23.1"
 
-dependencies = {
+deps = {
     "gh.toepproj.lit": "v0.23.1",
 }

--- a/__.pfsc
+++ b/__.pfsc
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------- #
 # The Toeplitz Project Expansions and Examples Library                        #
-# Copyright (c) 2011-2022 Toeplitz Project contributors                       #
+# Copyright (c) 2011-2024 Toeplitz Project contributors                       #
 #                                                                             #
 # This Source Code Form is subject to the terms of the Mozilla Public         #
 # License, v. 2.0. If a copy of the MPL was not distributed with this         #


### PR DESCRIPTION
Update for syntactic changes introduced in PISE v0.30.x

Also upgrade the `pfsc-repo-build-action` to `v3`.